### PR TITLE
Fixing loop range bug in pseudocode

### DIFF
--- a/md/CYK-Parse.md
+++ b/md/CYK-Parse.md
@@ -12,7 +12,7 @@ __function__ CYK-Parse(_words_, _grammar_) __returns__ _P_, a table of probabili
 &emsp;/\* Combine first and second parts of right-hand sides of rules, from short to long \*/  
 &emsp;__for__ _length_ = 2 __to__ _N_ __do__  
 &emsp;&emsp;__for__ _start_ = 1 __to__ _N_ - _length_ + 1 __do__  
-&emsp;&emsp;&emsp;__for__ _len1_ = 1 __to__ _N_ - 1 __do__  
+&emsp;&emsp;&emsp;__for__ _len1_ = 1 __to__ _length_ - 1 __do__  
 &emsp;&emsp;&emsp;&emsp;_len2_ &larr; _length_ - _len1_  
 &emsp;&emsp;&emsp;&emsp;__for each__ rule of the form (_X_ &rarr; _Y_ _Z_ [_p_]) __do__  
 &emsp;&emsp;&emsp;&emsp;&emsp;_P_[_X_, _start_, _length_] &larr; Max(_P_[_X_, _start_, _length_], _P_[_Y_, _start_, _len1_] x _P_[_Z_, _start_ + _len1_, _len2_] x _p_)  


### PR DESCRIPTION
when length = 2 (first iteration of outer loop), start = N-1 (last iteration of middle loop), and len1 = N-1 (last iteration of inner loop),
second index of the reference to P which is start + len1 equals
2*N - 2, that is out of the array bounds for N > 1

I have successfully implemented CYK in Java using this amended pseudocode. Without the amendment you get a NullPointerException

Credit to [izard](http://izard.livejournal.com/111415.html) for bug discovery back in 2012